### PR TITLE
Add default endpoint to exporter

### DIFF
--- a/example/basic_sample.py
+++ b/example/basic_sample.py
@@ -27,8 +27,7 @@ def parse_arguments():
                     "exporter.",
         epilog="The script can be run without any arguments. In that case, "
                "the local OneAgent is used as an endpoint, if it is installed.")
-    parser.add_argument("-e", "--endpoint", type=str, dest="endpoint",
-                        default="http://127.0.0.1:14499/metrics/ingest",
+    parser.add_argument("-e", "--endpoint", default=None, type=str, dest="endpoint",
                         help="The endpoint url used to export metrics to. "
                              "This can be either a Dynatrace metrics "
                              "ingestion endpoint, or a local OneAgent "
@@ -62,6 +61,10 @@ def parse_arguments():
 
 if __name__ == '__main__':
     args = parse_arguments()
+
+    if not args.endpoint:
+        print("No Dynatrace endpoint specified, exporting to default local "
+              "OneAgent ingest endpoint.")
 
     # set up opentelemetry for export:
     metrics.set_meter_provider(MeterProvider())

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -40,13 +40,18 @@ class DynatraceMetricsExporter(MetricsExporter):
 
     def __init__(
         self,
-        endpoint_url: str,
+        endpoint_url: Optional[str] = None,
         api_token: Optional[str] = None,
         prefix: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,
         export_oneagent_metadata: Optional[bool] = False,
     ):
-        self._endpoint_url = endpoint_url
+        if endpoint_url:
+            self._endpoint_url = endpoint_url
+        else:
+            self.__logger.info("No Dynatrace endpoint specified, exporting "
+                               "to default local OneAgent ingest endpoint.")
+            self._endpoint_url = "http://localhost:14499/metrics/ingest"
 
         all_tags = tags or {}
 


### PR DESCRIPTION
If no endpoint is provided, the default local OneAgent ingest API will be used.