### PR TITLE
Add metrics metadata

### DIFF
--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -67,6 +67,7 @@ class DynatraceMetricsExporter(MetricsExporter):
         self._headers = {
             "Accept": "*/*; q=0",
             "Content-Type": "text/plain; charset=utf-8",
+            "User-Agent": "opentelemetry-metric-python",
         }
         if api_token:
             if not endpoint_url:

--- a/src/dynatrace/opentelemetry/metrics/export/serializer.py
+++ b/src/dynatrace/opentelemetry/metrics/export/serializer.py
@@ -79,8 +79,10 @@ class DynatraceMetricsSerializer:
         # iteration.
         self._default_dimensions = self._normalize_dimensions(
             default_dimensions)
-        self._oneagent_dimensions = self._normalize_dimensions(
+
+        self._static_dimensions = self._normalize_dimensions(
             oneagent_dimensions)
+        self._static_dimensions["dt.metrics.source"] = "opentelemetry"
 
     @classmethod
     def _normalize_dimensions(cls, dimensions):
@@ -127,7 +129,7 @@ class DynatraceMetricsSerializer:
         unique_dimensions = self._make_unique_dimensions(
             self._default_dimensions,
             record.labels,
-            self._oneagent_dimensions)
+            self._static_dimensions)
 
         # add the merged dimension to the string builder.
         self._write_dimensions(string_buffer, unique_dimensions)

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -9,24 +9,36 @@ class TestExporterCreation(unittest.TestCase):
         exporter = DynatraceMetricsExporter()
         self.assertEqual("http://localhost:14499/metrics/ingest",
                          exporter._endpoint_url)
-        self.assertEqual(2, len(exporter._headers))
+        self.assertEqual(3, len(exporter._headers))
         self.assertNotIn("Authorization", exporter._headers)
         serializer = exporter._serializer
         self.assertEqual(None, serializer._prefix)
         self.assertDictEqual({}, serializer._default_dimensions)
-        self.assertDictEqual({}, serializer._oneagent_dimensions)
+        self.assertDictEqual({"dt.metrics.source": "opentelemetry"},
+                             serializer._static_dimensions)
 
     def test_with_endpoint(self):
         endpoint = "https://abc1234.dynatrace.com/metrics/ingest"
         exporter = DynatraceMetricsExporter(endpoint_url=endpoint)
 
         self.assertEqual(endpoint, exporter._endpoint_url)
-        self.assertEqual(2, len(exporter._headers))
+        self.assertEqual(3, len(exporter._headers))
         self.assertNotIn("Authorization", exporter._headers)
         serializer = exporter._serializer
         self.assertEqual(None, serializer._prefix)
         self.assertDictEqual({}, serializer._default_dimensions)
-        self.assertDictEqual({}, serializer._oneagent_dimensions)
+        self.assertDictEqual({"dt.metrics.source": "opentelemetry"},
+                             serializer._static_dimensions)
+
+    def test_has_useragent_header(self):
+        endpoint = "https://abc1234.dynatrace.com/metrics/ingest"
+        exporter = DynatraceMetricsExporter(endpoint_url=endpoint)
+
+        self.assertEqual(endpoint, exporter._endpoint_url)
+        self.assertEqual(3, len(exporter._headers))
+        self.assertIn("User-Agent", exporter._headers)
+        self.assertEqual(exporter._headers["User-Agent"],
+                         "opentelemetry-metric-python")
 
     def test_with_endpoint_and_token(self):
         endpoint = "https://abc1234.dynatrace.com/metrics/ingest"
@@ -35,13 +47,14 @@ class TestExporterCreation(unittest.TestCase):
                                             api_token=token)
 
         self.assertEqual(endpoint, exporter._endpoint_url)
-        self.assertEqual(3, len(exporter._headers))
+        self.assertEqual(4, len(exporter._headers))
         self.assertEqual("Api-Token {}".format(token),
                          exporter._headers["Authorization"])
         serializer = exporter._serializer
         self.assertEqual(None, serializer._prefix)
         self.assertDictEqual({}, serializer._default_dimensions)
-        self.assertDictEqual({}, serializer._oneagent_dimensions)
+        self.assertDictEqual({"dt.metrics.source": "opentelemetry"},
+                             serializer._static_dimensions)
 
     def test_with_only_token(self):
         token = "my.secret.token"
@@ -49,12 +62,13 @@ class TestExporterCreation(unittest.TestCase):
 
         self.assertEqual("http://localhost:14499/metrics/ingest",
                          exporter._endpoint_url)
-        self.assertEqual(2, len(exporter._headers))
+        self.assertEqual(3, len(exporter._headers))
         self.assertNotIn("Authorization", exporter._headers)
         serializer = exporter._serializer
         self.assertEqual(None, serializer._prefix)
         self.assertDictEqual({}, serializer._default_dimensions)
-        self.assertDictEqual({}, serializer._oneagent_dimensions)
+        self.assertDictEqual({"dt.metrics.source": "opentelemetry"},
+                             serializer._static_dimensions)
 
     def test_with_prefix(self):
         prefix = "test_prefix"
@@ -84,11 +98,12 @@ class TestExporterCreation(unittest.TestCase):
         mock_func.return_value = ["oneagenttag1=oneagentvalue1",
                                   "oneagenttag2=oneagentvalue2"]
         expected = {"oneagenttag1": "oneagentvalue1",
-                    "oneagenttag2": "oneagentvalue2"}
+                    "oneagenttag2": "oneagentvalue2",
+                    "dt.metrics.source": "opentelemetry"}
 
         exporter = DynatraceMetricsExporter(export_oneagent_metadata=True)
         serializer = exporter._serializer
-        self.assertDictEqual(expected, serializer._oneagent_dimensions)
+        self.assertDictEqual(expected, serializer._static_dimensions)
 
     @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
            '.OneAgentMetadataEnricher._get_metadata_file_content')
@@ -107,14 +122,15 @@ class TestExporterCreation(unittest.TestCase):
         dimensions = {"tag1": "tv1", "tag2": "tv2"}
 
         expected_default = {"tag1": "tv1", "tag2": "tv2"}
-        expected_oneagent = {"oneagenttag1": "oneagentvalue1",
-                             "oneagenttag2": "oneagentvalue2"}
+        expected_static = {"oneagenttag1": "oneagentvalue1",
+                           "oneagenttag2": "oneagentvalue2",
+                           "dt.metrics.source": "opentelemetry"}
 
         exporter = DynatraceMetricsExporter(default_dimensions=dimensions,
                                             export_oneagent_metadata=True)
         serializer = exporter._serializer
-        self.assertDictEqual(expected_oneagent,
-                             serializer._oneagent_dimensions)
+        self.assertDictEqual(expected_static,
+                             serializer._static_dimensions)
         self.assertDictEqual(expected_default, serializer._default_dimensions)
 
 

--- a/test/test_serializer.py
+++ b/test/test_serializer.py
@@ -57,7 +57,7 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         serialized = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr,l1=v1,l2=v2 count,10 555\n", serialized)
+        self.assertEqual("my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 555\n", serialized)
 
     def test_sum_aggregator_delta(self):
         self._meter_provider.stateful = False
@@ -67,7 +67,7 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         result = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr,l1=v1,l2=v2 count,delta=10 555\n", result)
+        self.assertEqual("my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,delta=10 555\n", result)
 
     def test_min_max_sum_count_aggregator(self):
         aggregator = aggregate.MinMaxSumCountAggregator()
@@ -79,7 +79,7 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         result = self._serializer.serialize_records([record])
 
         self.assertEqual(
-            "my.instr,l1=v1,l2=v2 gauge,min=1,max=100,sum=111,count=3 999\n",
+            "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=1,max=100,sum=111,count=3 999\n",
             result
         )
 
@@ -90,7 +90,7 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         result = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr,l1=v1,l2=v2 count,20 777\n", result)
+        self.assertEqual("my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,20 777\n", result)
 
     def test_multiple_records(self):
         records = []
@@ -111,9 +111,9 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         serialized = self._serializer.serialize_records(records)
 
         self.assertEqual(
-            "my.instr,l1=v1,l2=v2 count,10 555\n"
-            "my.instr,l1=v1,l2=v2 gauge,min=1,max=100,sum=111,count=3 999\n"
-            "my.instr,l1=v1,l2=v2 count,20 777\n",
+            "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 555\n"
+            "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=1,max=100,sum=111,count=3 999\n"
+            "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,20 777\n",
             serialized,
         )
 
@@ -124,7 +124,7 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         serialized = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr count,10 555\n", serialized)
+        self.assertEqual("my.instr,dt.metrics.source=opentelemetry count,10 555\n", serialized)
 
     def test_prefix(self):
         prefix = "prefix"
@@ -135,7 +135,7 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         result = self._serializer.serialize_records([record])
 
-        self.assertEqual("prefix.my.instr,l1=v1,l2=v2 count,10 111\n", result)
+        self.assertEqual("prefix.my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 111\n", result)
 
     def test_tags(self):
         dimensions = {"t1": "tv1", "t2": "tv2"}
@@ -148,7 +148,7 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         result = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr,t1=tv1,t2=tv2,l1=v1,l2=v2 count,10 111\n",
+        self.assertEqual("my.instr,t1=tv1,t2=tv2,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 111\n",
                          result)
 
     def test_invalid_name(self):


### PR DESCRIPTION
* Rename `oneagent_dimensions` to `static_dimensions` and
* add `dt.metrics.source` to it.
* Add `User-Agent` header
* Adapt tests