### PR TITLE
Rename OneAgent metadata to Dynatrace Metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Upload Python Package to PyPI
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   publish:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,33 +11,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install Dependencies
-      run: |
-        pip install -U pip
-        pip install -U wheel setuptools tox
-    - run: tox -e lint
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Dependencies
+        run: |
+          pip install -U pip
+          pip install -U wheel setuptools tox
+      - run: tox -e lint
 
   build-and-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python-version: [ '3.6', '3.7', '3.8', '3.9', 'pypy3' ]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Dependencies
-      run: |
-        pip install -U pip
-        pip install -U wheel setuptools tox
-    - name: Test
-      run: tox -e py
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          pip install -U pip
+          pip install -U wheel setuptools tox
+      - name: Test
+        run: tox -e py

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 ## Getting started
 
+### Installation
+
+To install the [latest version from PyPI](https://pypi.org/project/opentelemetry-exporter-dynatrace-metrics/) run:
+
+```shell
+pip install opentelemetry-exporter-dynatrace-metrics
+```
+
 ### Usage
 
 The general setup of OpenTelemetry Python is explained in the official [Getting Started Guide](https://opentelemetry-python.readthedocs.io/en/stable/getting-started.html).
@@ -35,8 +43,8 @@ counter.add(25, {"dimension-1", "value-1"})
 To run the [example](example/basic_example.py), clone this repository and change to the `opentelemetry-metric-python` folder, then run:
 
 ```shell
-pip install .                       # install the Dynatrace exporter
-export LOGLEVEL=DEBUG               # (optional) Set the log level to debug to see more output (default is INFO)
+pip install .           # install the Dynatrace exporter
+export LOGLEVEL=DEBUG   # (optional) Set the log level to debug to see more output (default is INFO)
 python example/basic_example.py
 ```
 
@@ -80,29 +88,29 @@ The `prefix` parameter specifies an optional prefix, which is prepended to each 
 The `default_dimensions` parameter can be used to optionally specify a list of key/value pairs, which will be added as additional dimensions to all data points.
 Dimension keys are unique, and labels on instruments will overwrite the default dimensions if key collisions appear.
 
-#### Export OneAgent Metadata
+#### Export Dynatrace Metadata
 
-If running on a host with a running OneAgent, setting the `export_oneagent_metadata` option to `True` will export metadata collected by the OneAgent to the Dynatrace endpoint.
+If running on a host with a running OneAgent or a Dynatrace Operator, setting the `export_dynatrace_metadata` option to `True` will export metadata collected by the OneAgent to the Dynatrace endpoint.
 If no Dynatrace API endpoint is set, the default exporter endpoint will be the OneAgent endpoint, and this option will be set automatically.
-Therefore, if no endpoint is specified, we assume a OneAgent is running and export to it, including metadata.
-More information on the underlying OneAgent feature that is used by the exporter can be found in the
+Therefore, if no endpoint is specified, a OneAgent is assumed to be running and used as the export endpoint for all metric lines, including metadata.
+More information on the underlying Dynatrace metadata feature that is used by the exporter can be found in the
 [Dynatrace documentation](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/enrich-metrics/).
 
 ##### Dimensions precedence
 
-When specifying default dimensions, labels and OneAgent metadata enrichment, the precedence of dimensions with the same key is as follows:
-Default dimensions are overwritten by labels passed to instruments, which in turn are overwritten by the OneAgent dimensions (even though the likeliness of a collision here is very low, since the OneAgent metadata only contains [Dynatrace reserved dimensions](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/metric-ingestion-protocol/#syntax) starting with `dt.*`).
+When specifying default dimensions, labels and Dynatrace metadata enrichment, the precedence of dimensions with the same key is as follows:
+Default dimensions are overwritten by labels passed to instruments, which in turn are overwritten by the Dynatrace metadata dimensions (even though the likeliness of a collision here is very low, since the Dynatrace metadata only contains [Dynatrace reserved dimensions](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/metric-ingestion-protocol/#syntax) starting with `dt.*`).
 
 ## Development
 
 ### Requirements
 
-Just [`tox`](https://pypi.org/project/tox/)
+Just [`tox`](https://pypi.org/project/tox/).
 
 ### Running tests and lint
 
-*Test all supported python versions:* `tox`
-*Test all supported python versions in parallel:* `tox -p`
-*A particular python version:* `tox -e 38`
-*Current python version*: `tox -e py`
-*Lint*: `tox -e lint`
+* Test all supported python versions: `tox`
+* Test all supported python versions in parallel: `tox -p`
+* A particular python version: `tox -e 38`
+* Current python version: `tox -e py`
+* Lint: `tox -e lint`

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Dimension keys are unique, and labels on instruments will overwrite the default 
 
 #### Export Dynatrace Metadata
 
-If running on a host with a running OneAgent or a Dynatrace Operator, setting the `export_dynatrace_metadata` option to `True` will export metadata collected by the OneAgent to the Dynatrace endpoint.
+If running on a host with a running OneAgent, setting the `export_dynatrace_metadata` option to `True` will export metadata collected by the OneAgent to the Dynatrace endpoint.
 If no Dynatrace API endpoint is set, the default exporter endpoint will be the OneAgent endpoint, and this option will be set automatically.
 Therefore, if no endpoint is specified, a OneAgent is assumed to be running and used as the export endpoint for all metric lines, including metadata.
 More information on the underlying Dynatrace metadata feature that is used by the exporter can be found in the

--- a/example/basic_example.py
+++ b/example/basic_example.py
@@ -11,17 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import random
-import time
 
 from dynatrace.opentelemetry.metrics.export import DynatraceMetricsExporter
 from opentelemetry import metrics
 from opentelemetry.sdk.metrics import MeterProvider
+
 from os.path import splitext, basename
 import argparse
 import logging
 import os
 import psutil
+import random
+import time
 
 
 # Callback to gather cpu usage
@@ -60,9 +61,10 @@ def parse_arguments():
     parser.add_argument("-nm", "--no-metadata", dest="metadata_enrichment",
                         action="store_false",
                         help="Turn off Dynatrace Metadata enrichment. If no "
-                             "OneAgent is running on the machine, this is "
-                             "ignored. Otherwise, Dynatrace metadata will be "
-                             "added to each of the exported metric lines.")
+                             "OneAgent or Dynatrace operator is running on "
+                             "the host, this is ignored. Otherwise, Dynatrace "
+                             "metadata will be added to each of the exported "
+                             "metric lines.")
 
     parser.add_argument("-i", "--interval", default=10., type=float,
                         dest="interval",

--- a/example/basic_example.py
+++ b/example/basic_example.py
@@ -59,9 +59,9 @@ def parse_arguments():
 
     parser.add_argument("-nm", "--no-metadata", dest="metadata_enrichment",
                         action="store_false",
-                        help="Turn off OneAgent Metadata enrichment. If no "
+                        help="Turn off Dynatrace Metadata enrichment. If no "
                              "OneAgent is running on the machine, this is "
-                             "ignored. Otherwise, OneAgent metadata will be "
+                             "ignored. Otherwise, Dynatrace metadata will be "
                              "added to each of the exported metric lines.")
 
     parser.add_argument("-i", "--interval", default=10., type=float,
@@ -101,8 +101,8 @@ if __name__ == '__main__':
     logger.info("setting up Dynatrace metrics exporting interface.")
     exporter = DynatraceMetricsExporter(args.endpoint, args.token,
                                         prefix="otel.python",
-                                        export_oneagent_metadata=args
-                                            .metadata_enrichment)
+                                        export_dynatrace_metadata=
+                                        args.metadata_enrichment)
 
     logger.info("registering Dynatrace exporter with the global OpenTelemetry"
                 " instance...")
@@ -162,7 +162,6 @@ if __name__ == '__main__':
             requests_counter.add(random.randint(0, 35), testing_labels)
             requests_size.record(random.randint(0, 100), testing_labels)
             time.sleep(5)
-
 
     except KeyboardInterrupt:
         logger.info("shutting down...")

--- a/example/basic_example.py
+++ b/example/basic_example.py
@@ -61,7 +61,7 @@ def parse_arguments():
     parser.add_argument("-nm", "--no-metadata", dest="metadata_enrichment",
                         action="store_false",
                         help="Turn off Dynatrace Metadata enrichment. If no "
-                             "OneAgent or Dynatrace operator is running on "
+                             "OneAgent is running on "
                              "the host, this is ignored. Otherwise, Dynatrace "
                              "metadata will be added to each of the exported "
                              "metric lines.")

--- a/example/install_and_run.sh
+++ b/example/install_and_run.sh
@@ -10,12 +10,12 @@ else
 fi
 
 # change into the opentelemetry-metric-python folder if you haven't already
-python3 -m venv .venv 			`# create a new virtual environment in the current folder`
+python3 -m venv .venv   `# create a new virtual environment in the current folder`
 
 source .venv/bin/activate
-pip3 install --upgrade setuptools 	`# make sure setuptools and wheel are on the latest version`
-pip3 install psutil			`# for observing cpu and ram`
-pip3 install . 				`# install the library itself`
+pip3 install --upgrade setuptools   `# make sure setuptools and wheel are on the latest version`
+pip3 install psutil                 `# for observing cpu and ram`
+pip3 install .                      `# install the library itself`
 # Valid log levels are: DEBUG, INFO, WARN/WARNING, ERROR, CRITICAL/FATAL
-export LOGLEVEL=DEBUG			`# set the log level`
-python3 example/basic_example.py	`# run the example in a venv`
+export LOGLEVEL=DEBUG               `# set the log level`
+python3 example/basic_example.py    `# run the example in a venv`

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -112,7 +112,8 @@ class DynatraceMetricsExporter(MetricsExporter):
                 headers=self._headers,
             ) as resp:
                 resp.raise_for_status()
-                self.__logger.debug("got response: " + resp.content)
+                self.__logger.debug("got response: " +
+                                    resp.content.decode("utf-8"))
         except Exception as ex:
             self.__logger.warning("Failed to export metrics: %s", ex)
             return MetricsExportResult.FAILURE

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -23,7 +23,7 @@ from opentelemetry.sdk.metrics.export import (
 )
 
 from .serializer import DynatraceMetricsSerializer
-from .oneagentmetadataenricher import OneAgentMetadataEnricher
+from .dynatracemetadataenricher import DynatraceMetadataEnricher
 
 VERSION = "0.1.0b0"
 
@@ -43,7 +43,7 @@ class DynatraceMetricsExporter(MetricsExporter):
         api_token: Optional[str] = None,
         prefix: Optional[str] = None,
         default_dimensions: Optional[Mapping[str, str]] = None,
-        export_oneagent_metadata: Optional[bool] = False,
+        export_dynatrace_metadata: Optional[bool] = False,
     ):
         self.__logger = logging.getLogger(__name__)
 
@@ -54,15 +54,16 @@ class DynatraceMetricsExporter(MetricsExporter):
                                "to default local OneAgent ingest endpoint.")
             self._endpoint_url = "http://localhost:14499/metrics/ingest"
 
-        oneagent_dims = {}
+        dynatrace_metadata_dims = {}
 
-        if export_oneagent_metadata:
-            enricher = OneAgentMetadataEnricher()
-            enricher.add_oneagent_metadata_to_dimensions(oneagent_dims)
+        if export_dynatrace_metadata:
+            enricher = DynatraceMetadataEnricher()
+            enricher.add_dynatrace_metadata_to_dimensions(
+                dynatrace_metadata_dims)
 
         self._serializer = DynatraceMetricsSerializer(prefix,
                                                       default_dimensions,
-                                                      oneagent_dims)
+                                                      dynatrace_metadata_dims)
         self._session = requests.Session()
         self._headers = {
             "Accept": "*/*; q=0",

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -25,7 +25,7 @@ from opentelemetry.sdk.metrics.export import (
 from .serializer import DynatraceMetricsSerializer
 from .dynatracemetadataenricher import DynatraceMetadataEnricher
 
-VERSION = "0.1.0b0"
+VERSION = "0.1.0b1"
 
 
 class DynatraceMetricsExporter(MetricsExporter):

--- a/src/dynatrace/opentelemetry/metrics/export/dynatracemetadataenricher.py
+++ b/src/dynatrace/opentelemetry/metrics/export/dynatracemetadataenricher.py
@@ -16,13 +16,13 @@ import logging
 from typing import List, Mapping
 
 
-class OneAgentMetadataEnricher:
+class DynatraceMetadataEnricher:
     def __init__(self) -> None:
         self.__logger = logging.getLogger(__name__)
 
-    def add_oneagent_metadata_to_dimensions(self, tags: Mapping[str, str]):
+    def add_dynatrace_metadata_to_dimensions(self, tags: Mapping[str, str]):
         metadata_file_content = self._get_metadata_file_content()
-        parsed_metadata = self._parse_oneagent_metadata(metadata_file_content)
+        parsed_metadata = self._parse_dynatrace_metadata(metadata_file_content)
         for key, value in parsed_metadata.items():
             tags[key] = value
 
@@ -36,11 +36,11 @@ class OneAgentMetadataEnricher:
                 file_name = metadata_indirection_file.read()
 
             if not file_name:
-                self.__logger.warning("OneAgent metadata file not specified "
+                self.__logger.warning("Dynatrace metadata file not specified "
                                       "in indirection file.")
 
         except OSError:
-            self.__logger.warning("Could not read local OneAgent metadata "
+            self.__logger.warning("Could not read local Dynatrace metadata "
                                   "enrichment file. This is normal if no "
                                   "OneAgent is installed.")
 
@@ -59,11 +59,11 @@ class OneAgentMetadataEnricher:
                 return attributes_file.readlines()
         except OSError:
             self.__logger.info(
-                "Could not read OneAgent metadata file ({}).".format(
+                "Could not read Dynatrace metadata file ({}).".format(
                     metadata_file_name))
             return []
 
-    def _parse_oneagent_metadata(self, lines) -> Mapping[str, str]:
+    def _parse_dynatrace_metadata(self, lines) -> Mapping[str, str]:
         key_value_pairs = {}
         for line in lines:
             self.__logger.debug("Parsing line {}".format(line.rstrip("\n")))

--- a/src/dynatrace/opentelemetry/metrics/export/serializer.py
+++ b/src/dynatrace/opentelemetry/metrics/export/serializer.py
@@ -70,7 +70,7 @@ class DynatraceMetricsSerializer:
         self,
         prefix: Optional[str] = "",
         default_dimensions: Optional[Mapping] = None,
-        oneagent_dimensions: Optional[Mapping] = None,
+        dynatrace_metadata_dimensions: Optional[Mapping] = None,
     ):
         self._prefix = prefix
         self._is_delta_export = None
@@ -81,7 +81,7 @@ class DynatraceMetricsSerializer:
             default_dimensions)
 
         self._static_dimensions = self._normalize_dimensions(
-            oneagent_dimensions)
+            dynatrace_metadata_dimensions)
         self._static_dimensions["dt.metrics.source"] = "opentelemetry"
 
     @classmethod
@@ -123,6 +123,7 @@ class DynatraceMetricsSerializer:
         metric_key = self._get_metric_key(record)
         if metric_key == "":
             return
+        
         string_buffer.append(metric_key)
 
         # merge dimensions to make them unique
@@ -133,8 +134,8 @@ class DynatraceMetricsSerializer:
 
         # add the merged dimension to the string builder.
         self._write_dimensions(string_buffer, unique_dimensions)
-
         serialize_func(string_buffer, aggregator)
+
         self._write_timestamp(string_buffer, aggregator)
         string_buffer.append("\n")
 
@@ -305,10 +306,11 @@ class DynatraceMetricsSerializer:
                                 default_dimensions: typing.Dict[str, str],
                                 labels: Iterable[Tuple[str, str]],
                                 one_agent_dimensions: typing.Dict[str, str]):
-        """Merge default dimensions, user specified dimensions and OneAgent
-        dimensions. default dimensions will be overwritten by user-specified
-        dimensions, which will be overwritten by OneAgent dimensions.
-        Default and OneAgent dimensions are assumed to be normalized when
+        """Merge default dimensions, user specified dimensions and Dynatrace
+        metadata dimensions. Default dimensions will be overwritten by
+        user-specified dimensions, which will be overwritten by Dynatrace
+        metadata dimensions.
+        Default and metadata dimensions are expected to be normalized when
         they are passed to this function."""
         dims_map = {}
 
@@ -323,7 +325,7 @@ class DynatraceMetricsSerializer:
                     dims_map[key] = cls._normalize_dimension_value(v)
 
         # overwrite dimensions that the user set with the default dimensions
-        # and OneAgent metadata. Tags are normalized in __init__ so they
+        # and Dynatrace metadata. Tags are normalized in __init__ so they
         # don't have to be re-normalized here.
         if one_agent_dimensions:
             for k, v in one_agent_dimensions.items():

--- a/src/dynatrace/opentelemetry/metrics/export/serializer.py
+++ b/src/dynatrace/opentelemetry/metrics/export/serializer.py
@@ -123,7 +123,7 @@ class DynatraceMetricsSerializer:
         metric_key = self._get_metric_key(record)
         if metric_key == "":
             return
-        
+
         string_buffer.append(metric_key)
 
         # merge dimensions to make them unique

--- a/test/test_dynatracemetadataenricher.py
+++ b/test/test_dynatracemetadataenricher.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
+
 import os
-import unittest
 import tempfile
+import unittest
 from unittest.mock import patch, mock_open
 
 from dynatrace.opentelemetry.metrics.export import DynatraceMetadataEnricher

--- a/test/test_dynatracemetadataenricher.py
+++ b/test/test_dynatracemetadataenricher.py
@@ -17,35 +17,35 @@ import unittest
 import tempfile
 from unittest.mock import patch, mock_open
 
-from dynatrace.opentelemetry.metrics.export import OneAgentMetadataEnricher
+from dynatrace.opentelemetry.metrics.export import DynatraceMetadataEnricher
 
 
-class TestOneAgentMetadataEnricher(unittest.TestCase):
+class TestDynatraceMetadataEnricher(unittest.TestCase):
 
-    def test_parse_oneagent_metadata(self):
-        enricher = OneAgentMetadataEnricher()
-        parsed = enricher._parse_oneagent_metadata(["key1=value1",
-                                                    "key2=value2"])
+    def test_parse_dynatrace_metadata(self):
+        enricher = DynatraceMetadataEnricher()
+        parsed = enricher._parse_dynatrace_metadata(["key1=value1",
+                                                     "key2=value2"])
 
         self.assertEqual("value1", parsed["key1"])
         self.assertEqual("value2", parsed["key2"])
         self.assertEqual(2, len(parsed))
 
     def test_parse_invalid_metadata(self):
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
 
-        self.assertFalse(enricher._parse_oneagent_metadata(
+        self.assertFalse(enricher._parse_dynatrace_metadata(
             ["=0x5c14d9a68d569861"]))
-        self.assertFalse(enricher._parse_oneagent_metadata(["otherKey="]))
-        self.assertFalse(enricher._parse_oneagent_metadata([""]))
-        self.assertFalse(enricher._parse_oneagent_metadata(["="]))
-        self.assertFalse(enricher._parse_oneagent_metadata(["==="]))
-        self.assertFalse(enricher._parse_oneagent_metadata([]))
+        self.assertFalse(enricher._parse_dynatrace_metadata(["otherKey="]))
+        self.assertFalse(enricher._parse_dynatrace_metadata([""]))
+        self.assertFalse(enricher._parse_dynatrace_metadata(["="]))
+        self.assertFalse(enricher._parse_dynatrace_metadata(["==="]))
+        self.assertFalse(enricher._parse_dynatrace_metadata([]))
 
     def test_valid_and_invalid(self):
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
 
-        parsed = enricher._parse_oneagent_metadata([
+        parsed = enricher._parse_dynatrace_metadata([
             "validKey1=validValue1",
             "=invalidKey",
             "invalidValue=",
@@ -59,34 +59,34 @@ class TestOneAgentMetadataEnricher(unittest.TestCase):
 
 
 class TestParseMetadata(unittest.TestCase):
-    @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
-           '.OneAgentMetadataEnricher._parse_oneagent_metadata')
+    @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
+           '.DynatraceMetadataEnricher._parse_dynatrace_metadata')
     def test_mock_get_metadata_file(self, mock_func):
         mock_func.return_value = {"k1": "v1", "k2": "v2"}
 
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
         # put something in the map to make sure items are added and not
         # overwritten.
         tags = {"tag1": "value1"}
-        enricher.add_oneagent_metadata_to_dimensions(tags)
+        enricher.add_dynatrace_metadata_to_dimensions(tags)
 
         self.assertEqual(tags, {"tag1": "value1", "k1": "v1", "k2": "v2"})
 
-    @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
-           '.OneAgentMetadataEnricher._parse_oneagent_metadata')
+    @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
+           '.DynatraceMetadataEnricher._parse_dynatrace_metadata')
     def test_tags_overwritten(self, mock_func):
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
         tags = {"tag1": "value1"}
         mock_func.return_value = {"tag1": "newValue"}
 
-        enricher.add_oneagent_metadata_to_dimensions(tags)
+        enricher.add_dynatrace_metadata_to_dimensions(tags)
 
         self.assertEqual(tags, {"tag1": "newValue"})
 
     def test_parse_valid_data(self):
         in_list = ["k1=v1\n", "k2=v2"]
-        enricher = OneAgentMetadataEnricher()
-        res = enricher._parse_oneagent_metadata(in_list)
+        enricher = DynatraceMetadataEnricher()
+        res = enricher._parse_dynatrace_metadata(in_list)
 
         self.assertEqual(2, len(res))
         self.assertEqual("v1", res["k1"])
@@ -94,8 +94,8 @@ class TestParseMetadata(unittest.TestCase):
 
     def test_parse_empty_list(self):
         in_list = []
-        enricher = OneAgentMetadataEnricher()
-        res = enricher._parse_oneagent_metadata(in_list)
+        enricher = DynatraceMetadataEnricher()
+        res = enricher._parse_dynatrace_metadata(in_list)
 
         self.assertEqual(0, len(res))
 
@@ -104,7 +104,7 @@ class TestGetIndirectionFile(unittest.TestCase):
     def test_get_indirection_file_contents_success(self):
         # when open is called, a file with this content is returned
         mock = mock_open(read_data="metadata_file_name")
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
         with patch("builtins.open", mock):
             res = enricher._get_metadata_file_name("not-used-since-mocking")
             self.assertEqual("metadata_file_name", res)
@@ -113,13 +113,13 @@ class TestGetIndirectionFile(unittest.TestCase):
         # will throw an IOError when calling open
         mock = mock_open()
         mock.side_effect = IOError()
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
         with patch("builtins.open", mock):
             res = enricher._get_metadata_file_name("not-used-since-mocking")
             self.assertEqual(None, res)
 
     def test_get_indirection_fname_missing_empty_or_invalid(self):
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
         self.assertEqual(None, enricher._get_metadata_file_name(""))
         self.assertEqual(None, enricher._get_metadata_file_name(None))
         self.assertEqual(None, enricher._get_metadata_file_name("#%&^:"))
@@ -128,7 +128,7 @@ class TestGetIndirectionFile(unittest.TestCase):
 class TestGetMetadataContents(unittest.TestCase):
     def test_indirection_file_empty(self):
         mock = mock_open(read_data="")
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
 
         with patch("builtins.open", mock):
             res = enricher._get_metadata_file_content()
@@ -145,26 +145,26 @@ class TestGetMetadataContents(unittest.TestCase):
                             ["indirection_filename",
                              "key1=value1\nkey2=value2"]]
 
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
         with patch("builtins.open", mock):
             res = enricher._get_metadata_file_content()
             self.assertEqual(2, len(res))
             # at this stage, values are not yet parsed. removing trailing 
-            # whitespace is done in the _parse_oneagent_metadata function.
+            # whitespace is done in the _parse_dynatrace_metadata function.
             self.assertEqual("key1=value1\n", res[0])
             self.assertEqual("key2=value2", res[1])
 
-    @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
-           '.OneAgentMetadataEnricher._get_metadata_file_name')
+    @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
+           '.DynatraceMetadataEnricher._get_metadata_file_name')
     def test_get_file_contents_from_none(self, mock_func):
         mock_func.return_value = None
 
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
         res = enricher._get_metadata_file_content()
         self.assertEqual(0, len(res))
 
-    @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
-           '.OneAgentMetadataEnricher._get_metadata_file_name')
+    @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
+           '.DynatraceMetadataEnricher._get_metadata_file_name')
     def test_get_file_contents_from_tmpfile(self, mock_func):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmpfile_name = os.path.join(tmp_dir, "tmp_file")
@@ -173,14 +173,14 @@ class TestGetMetadataContents(unittest.TestCase):
 
             mock_func.return_value = tmpfile_name
 
-            enricher = OneAgentMetadataEnricher()
+            enricher = DynatraceMetadataEnricher()
             res = enricher._get_metadata_file_content()
             self.assertEqual(2, len(res))
             self.assertEqual("key1=value1\n", res[0])
             self.assertEqual("key2=value2", res[1])
 
-    @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
-           '.OneAgentMetadataEnricher._get_metadata_file_name')
+    @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
+           '.DynatraceMetadataEnricher._get_metadata_file_name')
     def test_get_file_contents_from_nonexistent_file(self, mock_func):
         temp = tempfile.NamedTemporaryFile()
         mock_func.return_value = temp.name
@@ -188,16 +188,16 @@ class TestGetMetadataContents(unittest.TestCase):
         # not exist any more
         temp.close()
 
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
         # will try to read from the not-anymore-existing tempfile
         res = enricher._get_metadata_file_content()
         self.assertEqual(0, len(res))
 
-    @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
-           '.OneAgentMetadataEnricher._get_metadata_file_name')
+    @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
+           '.DynatraceMetadataEnricher._get_metadata_file_name')
     def test_get_file_contents_from_invalid_filename(self, mock_func):
         mock_func.return_value = "^%#&"
 
-        enricher = OneAgentMetadataEnricher()
+        enricher = DynatraceMetadataEnricher()
         res = enricher._get_metadata_file_content()
         self.assertEqual(0, len(res))

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -92,42 +92,42 @@ class TestExporterCreation(unittest.TestCase):
         serializer = exporter._serializer
         self.assertDictEqual({}, serializer._default_dimensions)
 
-    @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
-           '.OneAgentMetadataEnricher._get_metadata_file_content')
-    def test_oneagent_enrichment_valid_tags(self, mock_func):
-        mock_func.return_value = ["oneagenttag1=oneagentvalue1",
-                                  "oneagenttag2=oneagentvalue2"]
-        expected = {"oneagenttag1": "oneagentvalue1",
-                    "oneagenttag2": "oneagentvalue2",
+    @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
+           '.DynatraceMetadataEnricher._get_metadata_file_content')
+    def test_dynatrace_metadata_enrichment_valid_tags(self, mock_func):
+        mock_func.return_value = ["dynatrace_metadatatag1=dynatrace_metadatavalue1",
+                                  "dynatrace_metadatatag2=dynatrace_metadatavalue2"]
+        expected = {"dynatrace_metadatatag1": "dynatrace_metadatavalue1",
+                    "dynatrace_metadatatag2": "dynatrace_metadatavalue2",
                     "dt.metrics.source": "opentelemetry"}
 
-        exporter = DynatraceMetricsExporter(export_oneagent_metadata=True)
+        exporter = DynatraceMetricsExporter(export_dynatrace_metadata=True)
         serializer = exporter._serializer
         self.assertDictEqual(expected, serializer._static_dimensions)
 
-    @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
-           '.OneAgentMetadataEnricher._get_metadata_file_content')
-    def test_oneagent_enrichment_empty_tags(self, mock_func):
+    @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
+           '.DynatraceMetadataEnricher._get_metadata_file_content')
+    def test_dynatrace_metadata_enrichment_empty_tags(self, mock_func):
         mock_func.return_value = []
 
-        exporter = DynatraceMetricsExporter(export_oneagent_metadata=True)
+        exporter = DynatraceMetricsExporter(export_dynatrace_metadata=True)
         serializer = exporter._serializer
         self.assertDictEqual({}, serializer._default_dimensions)
 
-    @patch('dynatrace.opentelemetry.metrics.export.oneagentmetadataenricher'
-           '.OneAgentMetadataEnricher._get_metadata_file_content')
-    def test_oneagent_enrichment_empty_add_to_tags(self, mock_func):
-        mock_func.return_value = ["oneagenttag1=oneagentvalue1",
-                                  "oneagenttag2=oneagentvalue2"]
+    @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
+           '.DynatraceMetadataEnricher._get_metadata_file_content')
+    def test_dynatrace_metadata_enrichment_empty_add_to_tags(self, mock_func):
+        mock_func.return_value = ["dynatrace_metadatatag1=dynatrace_metadatavalue1",
+                                  "dynatrace_metadatatag2=dynatrace_metadatavalue2"]
         dimensions = {"tag1": "tv1", "tag2": "tv2"}
 
         expected_default = {"tag1": "tv1", "tag2": "tv2"}
-        expected_static = {"oneagenttag1": "oneagentvalue1",
-                           "oneagenttag2": "oneagentvalue2",
+        expected_static = {"dynatrace_metadatatag1": "dynatrace_metadatavalue1",
+                           "dynatrace_metadatatag2": "dynatrace_metadatavalue2",
                            "dt.metrics.source": "opentelemetry"}
 
         exporter = DynatraceMetricsExporter(default_dimensions=dimensions,
-                                            export_oneagent_metadata=True)
+                                            export_dynatrace_metadata=True)
         serializer = exporter._serializer
         self.assertDictEqual(expected_static,
                              serializer._static_dimensions)

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Dynatrace LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from unittest.mock import patch
 

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -95,8 +95,9 @@ class TestExporterCreation(unittest.TestCase):
     @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
            '.DynatraceMetadataEnricher._get_metadata_file_content')
     def test_dynatrace_metadata_enrichment_valid_tags(self, mock_func):
-        mock_func.return_value = ["dynatrace_metadatatag1=dynatrace_metadatavalue1",
-                                  "dynatrace_metadatatag2=dynatrace_metadatavalue2"]
+        mock_func.return_value = [
+            "dynatrace_metadatatag1=dynatrace_metadatavalue1",
+            "dynatrace_metadatatag2=dynatrace_metadatavalue2"]
         expected = {"dynatrace_metadatatag1": "dynatrace_metadatavalue1",
                     "dynatrace_metadatatag2": "dynatrace_metadatavalue2",
                     "dt.metrics.source": "opentelemetry"}
@@ -117,14 +118,16 @@ class TestExporterCreation(unittest.TestCase):
     @patch('dynatrace.opentelemetry.metrics.export.dynatracemetadataenricher'
            '.DynatraceMetadataEnricher._get_metadata_file_content')
     def test_dynatrace_metadata_enrichment_empty_add_to_tags(self, mock_func):
-        mock_func.return_value = ["dynatrace_metadatatag1=dynatrace_metadatavalue1",
-                                  "dynatrace_metadatatag2=dynatrace_metadatavalue2"]
+        mock_func.return_value = [
+            "dynatrace_metadatatag1=dynatrace_metadatavalue1",
+            "dynatrace_metadatatag2=dynatrace_metadatavalue2"]
         dimensions = {"tag1": "tv1", "tag2": "tv2"}
 
         expected_default = {"tag1": "tv1", "tag2": "tv2"}
-        expected_static = {"dynatrace_metadatatag1": "dynatrace_metadatavalue1",
-                           "dynatrace_metadatatag2": "dynatrace_metadatavalue2",
-                           "dt.metrics.source": "opentelemetry"}
+        expected_static = {
+            "dynatrace_metadatatag1": "dynatrace_metadatavalue1",
+            "dynatrace_metadatatag2": "dynatrace_metadatavalue2",
+            "dt.metrics.source": "opentelemetry"}
 
         exporter = DynatraceMetricsExporter(default_dimensions=dimensions,
                                             export_dynatrace_metadata=True)

--- a/test/test_serializer.py
+++ b/test/test_serializer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from collections import OrderedDict
 from typing import Union
 from unittest import mock
 

--- a/test/test_serializer.py
+++ b/test/test_serializer.py
@@ -57,7 +57,9 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         serialized = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 555\n", serialized)
+        self.assertEqual(
+            "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 555\n",
+            serialized)
 
     def test_sum_aggregator_delta(self):
         self._meter_provider.stateful = False
@@ -67,7 +69,9 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         result = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,delta=10 555\n", result)
+        self.assertEqual(
+            "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,delta=10 555\n",
+            result)
 
     def test_min_max_sum_count_aggregator(self):
         aggregator = aggregate.MinMaxSumCountAggregator()
@@ -90,7 +94,9 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         result = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,20 777\n", result)
+        self.assertEqual(
+            "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,20 777\n",
+            result)
 
     def test_multiple_records(self):
         records = []
@@ -124,7 +130,9 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         serialized = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr,dt.metrics.source=opentelemetry count,10 555\n", serialized)
+        self.assertEqual(
+            "my.instr,dt.metrics.source=opentelemetry count,10 555\n",
+            serialized)
 
     def test_prefix(self):
         prefix = "prefix"
@@ -135,7 +143,9 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         result = self._serializer.serialize_records([record])
 
-        self.assertEqual("prefix.my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 111\n", result)
+        self.assertEqual(
+            "prefix.my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 111\n",
+            result)
 
     def test_tags(self):
         dimensions = {"t1": "tv1", "t2": "tv2"}
@@ -148,8 +158,9 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
         record = self._create_record(aggregator)
         result = self._serializer.serialize_records([record])
 
-        self.assertEqual("my.instr,t1=tv1,t2=tv2,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 111\n",
-                         result)
+        self.assertEqual(
+            "my.instr,t1=tv1,t2=tv2,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,10 111\n",
+            result)
 
     def test_invalid_name(self):
         metric = DummyMetric(".")
@@ -181,48 +192,48 @@ class TestDynatraceMetricsSerializer(unittest.TestCase):
     def test_make_unique_dimensions_empty(self):
         default_dims = {}
         user_dims = {}
-        oneagent_dims = {}
+        dynatrace_metadata_dims = {}
 
         expected = {}
         got = serializer.DynatraceMetricsSerializer._make_unique_dimensions(
-            default_dims, user_dims, oneagent_dims)
+            default_dims, user_dims, dynatrace_metadata_dims)
 
         self.assertDictEqual(expected, got)
 
     def test_make_unique_dimensions_valid(self):
         default_dims = {"dim1": "dv1", "dim2": "dv2"}
         user_dims = [("tag1", "tv1"), ("tag2", "tv2")]
-        oneagent_dims = {"one1": "val1", "one2": "val2"}
+        dynatrace_metadata_dims = {"meta1": "val1", "meta2": "val2"}
 
         expected = {"tag1": "tv1", "tag2": "tv2", "dim1": "dv1", "dim2": "dv2",
-                    "one1": "val1", "one2": "val2"}
+                    "meta1": "val1", "meta2": "val2"}
         got = serializer.DynatraceMetricsSerializer._make_unique_dimensions(
-            default_dims, user_dims, oneagent_dims)
+            default_dims, user_dims, dynatrace_metadata_dims)
 
         self.assertDictEqual(expected, got)
 
     def test_make_unique_dimensions_overwrite(self):
-        defaultDims = {"dim1": "defv1", "dim2": "defv2", "dim3": "defv3"}
+        default_dims = {"dim1": "defv1", "dim2": "defv2", "dim3": "defv3"}
         dimensions = [("dim1", "dimv2"), ("dim2", "dimv2")]
-        oneAgentDims = {"dim1": "onev1"}
+        dynatrace_metadata_dims = {"dim1": "metav1"}
 
-        expected = {"dim1": "onev1", "dim2": "dimv2", "dim3": "defv3"}
+        expected = {"dim1": "metav1", "dim2": "dimv2", "dim3": "defv3"}
         got = serializer.DynatraceMetricsSerializer._make_unique_dimensions(
-            defaultDims, dimensions, oneAgentDims)
+            default_dims, dimensions, dynatrace_metadata_dims)
         self.assertDictEqual(expected, got)
 
     def test_make_unique_dimensions_overwrite_after_normalization(self):
-        # we assume the default dimensions and OneAgent dims to be
+        # we assume the default dimensions and DT metadata dims to be
         # well-formed here as that is done in the  constructor of the
         # DynatraceMetricsExporter, so no malformed tags  should ever be
         # passed to this function.
         default_dims = {"dim1": "defv1", "dim2": "defv2"}
         dims = [("~~!@$dim1", "dimv1"), ("@#$$%dim2", "dimv2")]
-        oneagent_dims = {}
+        dynatrace_metadata_dims = {}
 
         expected = {"dim1": "dimv1", "dim2": "dimv2"}
         got = serializer.DynatraceMetricsSerializer._make_unique_dimensions(
-            default_dims, dims, oneagent_dims)
+            default_dims, dims, dynatrace_metadata_dims)
 
         self.assertDictEqual(expected, got)
 

--- a/test/test_serializer_parametrized.py
+++ b/test/test_serializer_parametrized.py
@@ -174,7 +174,8 @@ cases_dimension_values = [
     ("invalid trailing unicode NUL", "a\u0000", "a"),
     ("invalid enclosed unicode NUL", "a\u0000b", "a_b"),
     (
-    "invalid consecutive enclosed unicode NUL", "a\u0000\u0007\u0000b", "a_b"),
+        "invalid consecutive enclosed unicode NUL", "a\u0000\u0007\u0000b",
+        "a_b"),
     ("invalid truncate value too long", "a" * 270, "a" * 250),
 ]
 


### PR DESCRIPTION
* Rename OneAgent Metadata
* Update the Readme
* Add a link and installation instructions to the PyPI release
* Clean up formatting