### PR TITLE
Use min/max from histogram data point.

### DIFF
--- a/example/basic_example.py
+++ b/example/basic_example.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
                                               export_dynatrace_metadata=args.metadata_enrichment,
                                               default_dimensions={"default1": "defval1"}))]))
 
-    meter = _metrics.get_meter(splitext(basename(__file__))[0])
+    meter = _metrics.get_meter(script_name)
 
     logger.info("creating instruments to record metrics data")
     requests_counter = meter.create_counter(

--- a/example/basic_example.py
+++ b/example/basic_example.py
@@ -21,24 +21,26 @@ from os.path import splitext, basename
 
 import psutil
 from opentelemetry import _metrics
-from opentelemetry._metrics.measurement import Measurement
 from opentelemetry.sdk._metrics import MeterProvider
 from opentelemetry.sdk._metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk._metrics.measurement import Measurement
 
 from dynatrace.opentelemetry.metrics.export import DynatraceMetricsExporter
 
+cpu_gauge = None
+ram_gauge = None
 
 # Callback to gather cpu usage
 def get_cpu_usage_callback():
     for (number, percent) in enumerate(psutil.cpu_percent(percpu=True)):
         attributes = {"cpu_number": str(number)}
-        yield Measurement(percent, attributes)
+        yield Measurement(percent, cpu_gauge, attributes)
 
 
 # Callback to gather RAM memory usage
 def get_ram_usage_callback():
     ram_percent = psutil.virtual_memory().percent
-    yield Measurement(ram_percent)
+    yield Measurement(ram_percent, ram_gauge)
 
 
 def parse_arguments():
@@ -125,15 +127,15 @@ if __name__ == '__main__':
         unit="byte"
     )
 
-    meter.create_observable_gauge(
-        callback=get_cpu_usage_callback,
+    cpu_gauge = meter.create_observable_gauge(
+        callbacks=[get_cpu_usage_callback],
         name="cpu_percent",
         description="per-cpu usage",
         unit="1"
     )
 
-    meter.create_observable_gauge(
-        callback=get_ram_usage_callback,
+    ram_gauge = meter.create_observable_gauge(
+        callbacks=[get_ram_usage_callback],
         name="ram_percent",
         description="RAM memory usage",
         unit="1",

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires=
-    opentelemetry-api~=1.10.0
-    opentelemetry-sdk~=1.10.0
+    opentelemetry-api~=1.11.1
+    opentelemetry-sdk~=1.11.1
     requests~=2.25
     dynatrace-metric-utils~=0.1.0b0
 

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -183,15 +183,12 @@ class DynatraceMetricsExporter(MetricExporter):
                         int(metric.point.time_unix_nano / 1000000))
 
             if isinstance(metric.point, Histogram):
-                count = sum(metric.point.bucket_counts)
-                avg = metric.point.sum / count
-
                 return self._metric_factory.create_float_summary(
                     metric.name,
-                    avg,
-                    avg,
+                    metric.point.min,
+                    metric.point.max,
                     metric.point.sum,
-                    count,
+                    sum(metric.point.bucket_counts),
                     attrs,
                     int(metric.point.time_unix_nano / 1000000))
 

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -46,12 +46,14 @@ def _get_histogram_max(histogram: Histogram):
     histogram_sum = histogram.sum
     histogram_count = sum(histogram.bucket_counts)
     if len(histogram.bucket_counts) == 1:
-        # In this case, only one bucket exists: (-Inf, Inf). If there were any boundaries,
-        # there would be more counts.
+        # In this case, only one bucket exists: (-Inf, Inf). If there were
+        # any boundaries, there would be more counts.
         if histogram.bucket_counts[0] > 0:
-            # in case the single bucket contains something, use the mean as max.
+            # in case the single bucket contains something, use the mean as
+            # max.
             return histogram_sum / histogram_count
-        # otherwise the histogram has no data. Use the sum as the min and max, respectively.
+        # otherwise the histogram has no data. Use the sum as the min and
+        # max, respectively.
         return histogram_sum
 
     # loop over bucket_counts in reverse
@@ -59,17 +61,19 @@ def _get_histogram_max(histogram: Histogram):
     for index in range(last_element_index, -1, -1):
         if histogram.bucket_counts[index] > 0:
             if index == last_element_index:
-                # use the last bound in the bounds array. This can only be the case if there is a count >
-                # 0 in the last bucket (lastBound, Inf), therefore, the bound has to be smaller than the
-                # actual maximum value, which in turn ensures that the sum is larger than the bound we
-                # use as max here.
+                # use the last bound in the bounds array. This can only be
+                # the case if there is a count > 0 in the last bucket (
+                # lastBound, Inf), therefore, the bound has to be smaller
+                # than the actual maximum value, which in turn ensures that
+                # the sum is larger than the bound we use as max here.
                 return histogram.explicit_bounds[index - 1]
-            # in any bucket except the last, make sure the sum is greater than or equal to the max,
-            # otherwise report the sum.
+            # in any bucket except the last, make sure the sum is greater
+            # than or equal to the max, otherwise report the sum.
             return min(histogram.explicit_bounds[index], histogram_sum)
 
-    # there are no counts > 0, so calculating a mean would result in a division by 0. By returning
-    # the sum, we can let the backend decide what to do with the value (with a count of 0)
+    # there are no counts > 0, so calculating a mean would result in a
+    # division by 0. By returning the sum, we can let the backend decide what
+    # to do with the value (with a count of 0)
     return histogram_sum
 
 
@@ -80,36 +84,39 @@ def _get_histogram_min(histogram: Histogram):
     histogram_sum = histogram.sum
     histogram_count = sum(histogram.bucket_counts)
     if len(histogram.bucket_counts) == 1:
-        # In this case, only one bucket exists: (-Inf, Inf). If there were any boundaries,
-        # there would be more counts.
+        # In this case, only one bucket exists: (-Inf, Inf). If there were
+        # any boundaries, there would be more counts.
         if histogram.bucket_counts[0] > 0:
-            # in case the single bucket contains something, use the mean as min.
+            # in case the single bucket contains something, use the mean as
+            # min.
             return histogram_sum / histogram_count
-        # otherwise the histogram has no data. Use the sum as the min and max, respectively.
+        # otherwise the histogram has no data. Use the sum as the min and
+        # max, respectively.
         return histogram_sum
 
     for index in range(0, len(histogram.bucket_counts)):
         if histogram.bucket_counts[index] > 0:
             if index == 0:
-                # If we are in the first bucket, use the upper bound (which is the lowest specified bound
-                # overall) otherwise this would be -Inf, which is not allowed. This is not quite correct,
-                # but the best approximation we can get at this point. This might however lead to a min
-                # that is bigger than the sum, therefore we return the min of the sum and the lowest
-                # bound.
-                # Choose the minimum of the following three:
-                # - The lowest boundary
-                # - The sum (smallest if there are multiple negative measurements smaller than the lowest
-                # boundary)
-                # - The average in the bucket (smallest if there are multiple positive measurements
-                # smaller than the lowest boundary)
+                # If we are in the first bucket, use the upper bound (which
+                # is the lowest specified bound overall) otherwise this would
+                # be -Inf, which is not allowed. This is not quite correct,
+                # but the best approximation we can get at this point. This
+                # might however lead to a min that is bigger than the sum,
+                # therefore we return the min of the sum and the lowest
+                # bound. Choose the minimum of the following three: - The
+                # lowest boundary - The sum (smallest if there are multiple
+                # negative measurements smaller than the lowest boundary) -
+                # The average in the bucket (smallest if there are multiple
+                # positive measurements smaller than the lowest boundary)
                 return min(
                     min(histogram.explicit_bounds[index], histogram_sum),
                     histogram_sum / histogram_count
                 )
             return histogram.explicit_bounds[index - 1]
 
-    # there are no counts > 0, so calculating a mean would result in a division by 0. By returning
-    # the sum, we can let the backend decide what to do with the value (with a count of 0)
+    # there are no counts > 0, so calculating a mean would result in a
+    # division by 0. By returning the sum, we can let the backend decide what
+    # to do with the value (with a count of 0)
     return histogram_sum
 
 

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -40,7 +40,7 @@ VERSION = "0.2.0b0"
 
 
 def _get_histogram_max(histogram: Histogram):
-    if math.isfinite(histogram.max):
+    if histogram.max is not None and math.isfinite(histogram.max):
         return histogram.max
 
     histogram_sum = histogram.sum
@@ -78,7 +78,7 @@ def _get_histogram_max(histogram: Histogram):
 
 
 def _get_histogram_min(histogram: Histogram):
-    if math.isfinite(histogram.min):
+    if histogram.min is not None and math.isfinite(histogram.min):
         return histogram.min
 
     histogram_sum = histogram.sum

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -43,7 +43,7 @@ def _get_histogram_max(histogram: Histogram):
     if math.isfinite(histogram.max):
         return histogram.max
 
-    histogram_sum = sum(histogram.bucket_counts)
+    histogram_sum = histogram.sum
     histogram_count = sum(histogram.bucket_counts)
     if len(histogram.bucket_counts) == 1:
         # In this case, only one bucket exists: (-Inf, Inf). If there were any boundaries,
@@ -63,10 +63,10 @@ def _get_histogram_max(histogram: Histogram):
                 # 0 in the last bucket (lastBound, Inf), therefore, the bound has to be smaller than the
                 # actual maximum value, which in turn ensures that the sum is larger than the bound we
                 # use as max here.
-                return histogram.explicit_bounds[index -1]
+                return histogram.explicit_bounds[index - 1]
             # in any bucket except the last, make sure the sum is greater than or equal to the max,
             # otherwise report the sum.
-            return min(histogram.explicit_bounds[0], histogram_sum)
+            return min(histogram.explicit_bounds[index], histogram_sum)
 
     # there are no counts > 0, so calculating a mean would result in a division by 0. By returning
     # the sum, we can let the backend decide what to do with the value (with a count of 0)
@@ -77,7 +77,7 @@ def _get_histogram_min(histogram: Histogram):
     if math.isfinite(histogram.min):
         return histogram.min
 
-    histogram_sum = sum(histogram.bucket_counts)
+    histogram_sum = histogram.sum
     histogram_count = sum(histogram.bucket_counts)
     if len(histogram.bucket_counts) == 1:
         # In this case, only one bucket exists: (-Inf, Inf). If there were any boundaries,
@@ -106,7 +106,7 @@ def _get_histogram_min(histogram: Histogram):
                     min(histogram.explicit_bounds[index], histogram_sum),
                     histogram_sum / histogram_count
                 )
-            return histogram.bucket_counts[index - 1]
+            return histogram.explicit_bounds[index - 1]
 
     # there are no counts > 0, so calculating a mean would result in a division by 0. By returning
     # the sum, we can let the backend decide what to do with the value (with a count of 0)

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -387,8 +387,8 @@ class TestExporterCreation(unittest.TestCase):
     def test_histogram_reported_as_gauge(self, mock_post):
         data_point = Histogram(bucket_counts=[1, 2, 4, 5],
                                explicit_bounds=[0, 5, 10],
-                               sum=36,
-                               min=1,
+                               sum=87,
+                               min=-3,
                                max=12,
                                aggregation_temporality=AggregationTemporality.DELTA,
                                time_unix_nano=self._test_timestamp_nanos,
@@ -401,15 +401,15 @@ class TestExporterCreation(unittest.TestCase):
         self.assertEqual(MetricExportResult.SUCCESS, result)
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
-            data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=1,max=12,sum=36,count=12 {0}\n"
+            data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=-3,max=12,sum=87,count=12 {0}\n"
                 .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
     def test_histogram_without_min_max_reported_as_estimated_gauge(self, mock_post):
-        data_point = Histogram(bucket_counts=[0, 1, 0, 3, 0, 4],
-                               explicit_bounds=[1, 2, 3, 4, 5],
-                               sum=10.234,
+        data_point = Histogram(bucket_counts=[1, 2, 4, 5],
+                               explicit_bounds=[0, 5, 10],
+                               sum=87,
                                min=math.inf,
                                max=-math.inf,
                                aggregation_temporality=AggregationTemporality.DELTA,
@@ -423,7 +423,7 @@ class TestExporterCreation(unittest.TestCase):
         self.assertEqual(MetricExportResult.SUCCESS, result)
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
-            data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=1,max=5,sum=10.234,count=8 {0}\n"
+            data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=0,max=10,sum=87,count=12 {0}\n"
                 .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
@@ -437,8 +437,8 @@ class TestExporterCreation(unittest.TestCase):
                                                  value=20)))
         records.append(self._create_record(Histogram(bucket_counts=[1, 2, 4, 5],
                                                      explicit_bounds=[0, 5, 10],
-                                                     sum=36,
-                                                     min=1,
+                                                     sum=87,
+                                                     min=-3,
                                                      max=12,
                                                      aggregation_temporality=AggregationTemporality.DELTA,
                                                      time_unix_nano=self._test_timestamp_nanos,
@@ -448,7 +448,7 @@ class TestExporterCreation(unittest.TestCase):
 
         expected = "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,delta=10 {0}\n" \
                    "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,20 {0}\n" \
-                   "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=1,max=12,sum=36,count=12 {0}\n" \
+                   "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=-3,max=12,sum=87,count=12 {0}\n" \
             .format(int(self._test_timestamp_millis))
 
         self.assertEqual(MetricExportResult.SUCCESS, result)

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -21,7 +21,7 @@ from opentelemetry.sdk._metrics.export import Metric, \
     MetricExportResult, PeriodicExportingMetricReader
 from opentelemetry.sdk._metrics.point import PointT, Gauge, Sum, AggregationTemporality, Histogram
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
+from opentelemetry.sdk.util.instrumentation import InstrumentationInfo, InstrumentationScope
 
 from dynatrace.opentelemetry.metrics.export import DynatraceMetricsExporter
 
@@ -222,7 +222,7 @@ class TestExporterCreation(unittest.TestCase):
                                 description="",
                                 unit="1",
                                 resource=Resource({}),
-                                instrumentation_info=InstrumentationInfo(
+                                instrumentation_scope=InstrumentationScope(
                                     name="dynatrace.opentelemetry.metrics.export",
                                     version="0.0.1"))
                 metrics.append(metric)
@@ -270,7 +270,7 @@ class TestExporterCreation(unittest.TestCase):
                                 description="",
                                 unit="1",
                                 resource=Resource({}),
-                                instrumentation_info=InstrumentationInfo(name="dynatrace.opentelemetry.metrics.export",
+                                instrumentation_scope=InstrumentationScope(name="dynatrace.opentelemetry.metrics.export",
                                                                          version="0.0.1"))
                 metrics.append(metric)
             else:
@@ -385,6 +385,8 @@ class TestExporterCreation(unittest.TestCase):
         data_point = Histogram(bucket_counts=[1, 2, 4, 5],
                                explicit_bounds=[0, 5, 10],
                                sum=36,
+                               min=1,
+                               max=12,
                                aggregation_temporality=AggregationTemporality.DELTA,
                                time_unix_nano=self._test_timestamp_nanos,
                                start_time_unix_nano=self._test_timestamp_nanos)
@@ -396,7 +398,7 @@ class TestExporterCreation(unittest.TestCase):
         self.assertEqual(MetricExportResult.SUCCESS, result)
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
-            data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=3,max=3,sum=36,count=12 {0}\n"
+            data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=1,max=12,sum=36,count=12 {0}\n"
                 .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
@@ -411,6 +413,8 @@ class TestExporterCreation(unittest.TestCase):
         records.append(self._create_record(Histogram(bucket_counts=[1, 2, 4, 5],
                                                      explicit_bounds=[0, 5, 10],
                                                      sum=36,
+                                                     min=1,
+                                                     max=12,
                                                      aggregation_temporality=AggregationTemporality.DELTA,
                                                      time_unix_nano=self._test_timestamp_nanos,
                                                      start_time_unix_nano=self._test_timestamp_nanos)))
@@ -419,7 +423,7 @@ class TestExporterCreation(unittest.TestCase):
 
         expected = "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,delta=10 {0}\n" \
                    "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,20 {0}\n" \
-                   "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=3,max=3,sum=36,count=12 {0}\n" \
+                   "my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=1,max=12,sum=36,count=12 {0}\n" \
             .format(int(self._test_timestamp_millis))
 
         self.assertEqual(MetricExportResult.SUCCESS, result)
@@ -465,7 +469,7 @@ class TestExporterCreation(unittest.TestCase):
                       description="",
                       unit="1",
                       resource=Resource({}),
-                      instrumentation_info=InstrumentationInfo(name="dynatrace.opentelemetry.metrics.export",
+                      instrumentation_scope=InstrumentationScope(name="dynatrace.opentelemetry.metrics.export",
                                                                version="0.0.1"))
 
     def _create_sum_data_point(self, value: int, monotonic=True) -> Sum:

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -20,7 +20,8 @@ import requests
 from opentelemetry.sdk._metrics import MeterProvider, View
 from opentelemetry.sdk._metrics.export import Metric, \
     MetricExportResult, PeriodicExportingMetricReader
-from opentelemetry.sdk._metrics.point import PointT, Gauge, Sum, AggregationTemporality, Histogram
+from opentelemetry.sdk._metrics.point import PointT, Gauge, Sum, \
+    AggregationTemporality, Histogram
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -58,7 +58,7 @@ class TestMax(unittest.TestCase):
     def test_get_max(self):
         #  A value between the last two boundaries.
         self.assertEqual(5,
-                         _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [0, 1, 0, 3, 0, 4], 10.234)))
+                         _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [0, 1, 0, 3, 2, 0], 10.234)))
         # last bucket has value, use the last boundary as estimation instead of Inf
         self.assertEqual(5,
                          _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [1, 0, 0, 3, 0, 4], 10.234)))

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1,0 +1,85 @@
+import math
+import unittest
+
+from typing import List
+from opentelemetry.sdk._metrics.point import Histogram, AggregationTemporality, Union
+
+from dynatrace.opentelemetry.metrics.export import _get_histogram_min, _get_histogram_max
+
+
+def create_histogram(explicit_bounds: List[int], bucket_counts: List[int], sum: Union[float, int]):
+    start_time = 1619687639000000000
+    end_time = 1619687639000000000
+    return Histogram(bucket_counts=bucket_counts,
+                     explicit_bounds=explicit_bounds,
+                     sum=sum,
+                     min=+math.inf,
+                     max=-math.inf,
+                     aggregation_temporality=AggregationTemporality.DELTA,
+                     time_unix_nano=end_time,
+                     start_time_unix_nano=start_time)
+
+
+class TestMin(unittest.TestCase):
+    def test_get_min(self):
+        # A value between the first two boundaries.
+        self.assertEqual(1,
+                         _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [0, 1, 0, 3, 0, 4], 10.234)))
+        # lowest bucket has value, use the first boundary as estimation instead of -Inf
+        self.assertEqual(1,
+                         _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [1, 0, 0, 3, 0, 4], 10.234)))
+        # lowest bucket (-Inf, 1) has values, mean is lower than the lowest bucket bound and smaller than the sum
+        self.assertAlmostEqual(0.234 / 3,
+                               _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [3, 0, 0, 0, 0, 0], 0.234)),
+                               delta=0.001)
+        # lowest bucket (-Inf, 0) has values, sum is lower than the lowest bucket bound
+        self.assertAlmostEqual(-25.3,
+                               _get_histogram_min(create_histogram([0, 5], [3, 0, 0], -25.3)),
+                               delta=0.001)
+        # no bucket has a value
+        self.assertAlmostEqual(10.234,
+                               _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 0], 10.234)),
+                               delta=0.001)
+        # just one bucket from -Inf to Inf, calc the mean as min value.
+        self.assertAlmostEqual(2.2,
+                               _get_histogram_min(create_histogram([], [4], 8.8)),
+                               delta=0.001)
+        # just one bucket from -Inf to Inf, with a count of 1
+        self.assertAlmostEqual(1.2,
+                               _get_histogram_min(create_histogram([], [1], 1.2)),
+                               delta=0.001)
+        # only the last bucket has a value (5, +Inf)
+        self.assertAlmostEqual(5,
+                               _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 1], 10.234)),
+                               delta=0.001)
+
+
+class TestMax(unittest.TestCase):
+    def test_get_max(self):
+        #  A value between the last two boundaries.
+        self.assertEqual(5,
+                         _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [0, 1, 0, 3, 0, 4], 10.234)))
+        # last bucket has value, use the last boundary as estimation instead of Inf
+        self.assertEqual(5,
+                         _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [1, 0, 0, 3, 0, 4], 10.234)))
+        # no bucket has a value
+        self.assertAlmostEqual(10.234,
+                               _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 0], 10.234)),
+                               delta=0.001)
+        # just one bucket from -Inf to Inf, calc the mean as max value.
+        self.assertAlmostEqual(2.2,
+                               _get_histogram_max(create_histogram([], [4], 8.8)),
+                               delta=0.001)
+        #  just one bucket from -Inf to Inf, with a count of 1
+        self.assertAlmostEqual(1.2,
+                               _get_histogram_max(create_histogram([], [1], 1.2)),
+                               delta=0.001)
+        # only the last bucket has a value (5, +Inf)
+        self.assertAlmostEqual(5,
+                               _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 1], 10.234)),
+                               delta=0.001)
+        # the max is greater than the sum
+        self.assertAlmostEqual(2.3,
+                               _get_histogram_max(create_histogram([-5, 0, 5], [0, 0, 2, 0], 2.3)),
+                               delta=0.001)
+


### PR DESCRIPTION
This PR updates the SDK version to `0.30b1` and makes use of the `min` and `max` fields that were added to the Histogram Data point. 

If `min` and/or `max` are not set, the  min/max estimation algorithm used in our other exporters is used.