### PR TITLE
Use updated histogram to gauge conversion algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,13 @@ Just [`tox`](https://pypi.org/project/tox/).
 * A particular python version: `tox -e 38`
 * Current python version: `tox -e py`
 * Lint: `tox -e lint`
+
+## Limitations
+
+### Histogram
+
+OpenTelemetry Histograms are exported to Dynatrace as statistical summaries
+consisting of a minimum and maximum value, the total sum of all values, and the
+count of the values summarized. If the min and max values are not directly
+available on the metric data point, estimations based on the boundaries of the
+first and last buckets containing values are used.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 tox
 pytest~=6.2.5
+parameterized~=0.8.1

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -99,8 +99,8 @@ def _get_histogram_min(histogram: Histogram):
         # the current bucket contains something.
         if histogram.bucket_counts[index] > 0:
             if index == 0:
-                # In the first bucket, (-Inf, firstBound], use firstBound (
-                # this is the lowest specified bound overall). This is not
+                # In the first bucket, (-Inf, firstBound], use firstBound 
+                # (this is the lowest specified bound overall). This is not
                 # quite correct but the best approximation we can get at
                 # this point. However, this might lead to a min bigger than
                 # the mean, thus choose the minimum of the following:

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -103,9 +103,9 @@ def _get_histogram_min(histogram: Histogram):
                 # this is the lowest specified bound overall). This is not
                 # quite correct but the best approximation we can get at
                 # this point. However, this might lead to a min bigger than
-                # the mean, thus choose the minimum of the following: - The
-                # lowest boundary - The average of the histogram (histogram
-                # sum / sum of counts)
+                # the mean, thus choose the minimum of the following:
+                # - The lowest boundary
+                # - The histogram's average (histogram sum / sum of counts)
                 return min(histogram.explicit_bounds[index],
                            histogram_sum / histogram_count)
             # In all other buckets (lowerBound, upperBound] use the

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -99,7 +99,7 @@ def _get_histogram_min(histogram: Histogram):
         # the current bucket contains something.
         if histogram.bucket_counts[index] > 0:
             if index == 0:
-                # In the first bucket, (-Inf, firstBound], use firstBound 
+                # In the first bucket, (-Inf, firstBound], use firstBound
                 # (this is the lowest specified bound overall). This is not
                 # quite correct but the best approximation we can get at
                 # this point. However, this might lead to a min bigger than

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -2,12 +2,18 @@ import math
 import unittest
 
 from typing import List
-from opentelemetry.sdk._metrics.point import Histogram, AggregationTemporality, Union
 
-from dynatrace.opentelemetry.metrics.export import _get_histogram_min, _get_histogram_max
+from parameterized import parameterized
+from opentelemetry.sdk._metrics.point import Histogram, \
+    AggregationTemporality, \
+    Union
+
+from dynatrace.opentelemetry.metrics.export import _get_histogram_min, \
+    _get_histogram_max
 
 
-def create_histogram(explicit_bounds: List[int], bucket_counts: List[int], sum: Union[float, int]):
+def create_histogram(explicit_bounds: List[int], bucket_counts: List[int],
+                     sum: Union[float, int]):
     start_time = 1619687639000000000
     end_time = 1619687639000000000
     return Histogram(bucket_counts=bucket_counts,
@@ -21,65 +27,64 @@ def create_histogram(explicit_bounds: List[int], bucket_counts: List[int], sum: 
 
 
 class TestMin(unittest.TestCase):
-    def test_get_min(self):
-        # A value between the first two boundaries.
-        self.assertEqual(1,
-                         _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [0, 1, 0, 3, 0, 4], 10.234)))
-        # lowest bucket has value, use the first boundary as estimation instead of -Inf
-        self.assertEqual(1,
-                         _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [1, 0, 0, 3, 0, 4], 10.234)))
-        # lowest bucket (-Inf, 1) has values, mean is lower than the lowest bucket bound and smaller than the sum
-        self.assertAlmostEqual(0.234 / 3,
-                               _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [3, 0, 0, 0, 0, 0], 0.234)),
-                               delta=0.001)
-        # lowest bucket (-Inf, 0) has values, sum is lower than the lowest bucket bound
-        self.assertAlmostEqual(-25.3,
-                               _get_histogram_min(create_histogram([0, 5], [3, 0, 0], -25.3)),
-                               delta=0.001)
-        # no bucket has a value
-        self.assertAlmostEqual(10.234,
-                               _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 0], 10.234)),
-                               delta=0.001)
-        # just one bucket from -Inf to Inf, calc the mean as min value.
-        self.assertAlmostEqual(2.2,
-                               _get_histogram_min(create_histogram([], [4], 8.8)),
-                               delta=0.001)
-        # just one bucket from -Inf to Inf, with a count of 1
-        self.assertAlmostEqual(1.2,
-                               _get_histogram_min(create_histogram([], [1], 1.2)),
-                               delta=0.001)
-        # only the last bucket has a value (5, +Inf)
-        self.assertAlmostEqual(5,
-                               _get_histogram_min(create_histogram([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 1], 10.234)),
-                               delta=0.001)
+    @parameterized.expand([
+        # Values between the first two boundaries.
+        ([1, 2, 3, 4, 5], [0, 1, 0, 3, 2, 0], 21.2, 1),
+        # First bucket has value, use the first boundary
+        # as estimation instead of Inf.
+        ([1, 2, 3, 4, 5], [1, 0, 0, 3, 0, 4], 34.5, 1),
+        # Only the first bucket has values, use the mean
+        # (0.25) Otherwise, the min would be estimated as
+        # 1, and min <= avg would be violated.
+        ([1, 2, 3, 4, 5], [3, 0, 0, 0, 0, 0], 0.75, 0.25),
+        # Just one bucket from -Inf to Inf, calculate the
+        # mean as min value.
+        ([], [4], 8.8, 2.2),
+        # Just one bucket from -Inf to Inf, calculate the
+        # mean as min value.
+        ([], [1], 1.2, 1.2),
+        # Only the last bucket has a value, use the lower
+        # bound.
+        ([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 3], 15.6, 5),
+    ])
+    def test_get_min(self, boundaries, buckets, histogram_sum, expected_min):
+        # Values between the first two boundaries.
+        self.assertEqual(expected_min,
+                         _get_histogram_min(
+                             create_histogram(boundaries,
+                                              buckets,
+                                              histogram_sum)))
 
 
 class TestMax(unittest.TestCase):
-    def test_get_max(self):
-        #  A value between the last two boundaries.
-        self.assertEqual(5,
-                         _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [0, 1, 0, 3, 2, 0], 10.234)))
-        # last bucket has value, use the last boundary as estimation instead of Inf
-        self.assertEqual(5,
-                         _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [1, 0, 0, 3, 0, 4], 10.234)))
-        # no bucket has a value
-        self.assertAlmostEqual(10.234,
-                               _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 0], 10.234)),
-                               delta=0.001)
-        # just one bucket from -Inf to Inf, calc the mean as max value.
-        self.assertAlmostEqual(2.2,
-                               _get_histogram_max(create_histogram([], [4], 8.8)),
-                               delta=0.001)
-        #  just one bucket from -Inf to Inf, with a count of 1
-        self.assertAlmostEqual(1.2,
-                               _get_histogram_max(create_histogram([], [1], 1.2)),
-                               delta=0.001)
-        # only the last bucket has a value (5, +Inf)
-        self.assertAlmostEqual(5,
-                               _get_histogram_max(create_histogram([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 1], 10.234)),
-                               delta=0.001)
-        # the max is greater than the sum
-        self.assertAlmostEqual(2.3,
-                               _get_histogram_max(create_histogram([-5, 0, 5], [0, 0, 2, 0], 2.3)),
-                               delta=0.001)
-
+    @parameterized.expand([
+        # Values between the first two boundaries.
+        ([1, 2, 3, 4, 5], [0, 1, 0, 3, 2, 0], 21.2, 5),
+        # Last bucket has value, use the last boundary as
+        # estimation instead of Inf.
+        ([1, 2, 3, 4, 5], [1, 0, 0, 3, 0, 4], 34.5, 5),
+        # Only the last bucket has values, use the
+        # mean (10.1) Otherwise, the max would be
+        # estimated as 5, and max >= avg would be
+        # violated.
+        ([1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 2], 20.2, 10.1),
+        # Just one bucket from -Inf to Inf, calculate
+        # the mean as max value.
+        ([], [4], 8.8, 2.2),
+        # Just one bucket from -Inf to Inf, calculate
+        # the mean as max value.
+        ([], [1], 1.2, 1.2),
+        # Max is larger than the sum, use the
+        # estimated boundary.
+        ([0, 5], [0, 2, 0], 2.3, 5),
+        # Only the last bucket has a value, use the lower
+        # bound.
+        ([1, 2, 3, 4, 5], [3, 0, 0, 0, 0, 0], 1.5, 1),
+    ])
+    def test_get_max(self, boundaries, buckets, histogram_sum, expected_max):
+        # Values between the first two boundaries.
+        self.assertEqual(expected_max,
+                         _get_histogram_max(
+                             create_histogram(boundaries,
+                                              buckets,
+                                              histogram_sum)))

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,9 @@ envlist =
     lint
 
 [testenv]
-deps = pytest
+deps =
+    pytest
+    parameterized
 commands =
     pytest -v
 


### PR DESCRIPTION
This PR updates the histogram to gauge estimation so that the statement `min <= mean <= max` holds for all histograms that are converted to gauges.