### PR TITLE
Drop unsupported non-string attribute values

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ Just [`tox`](https://pypi.org/project/tox/).
 
 ## Limitations
 
+### Typed attributes support
+
+The OpenTelemetry Metrics API for Java supports the concept
+of [Attributes]( https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes).
+These attributes consist of key-value pairs, where the keys are strings and the
+values are either primitive types or arrays of uniform primitive types.
+
+At the moment, this exporter **only supports attributes with string key and
+value type**.
+This means that if attributes of any other type are used, they will be 
+**ignored** and **only** the string-valued attributes are going to be sent to
+Dynatrace.
+
 ### Histogram
 
 OpenTelemetry Histograms are exported to Dynatrace as statistical summaries

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Just [`tox`](https://pypi.org/project/tox/).
 
 ### Typed attributes support
 
-The OpenTelemetry Metrics API for Java supports the concept
+The OpenTelemetry Metrics API for Python supports the concept
 of [Attributes]( https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes).
 These attributes consist of key-value pairs, where the keys are strings and the
 values are either primitive types or arrays of uniform primitive types.

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires=
     opentelemetry-api~=1.12.0
     opentelemetry-sdk~=1.12.0
     requests~=2.25
-    dynatrace-metric-utils~=0.2.0
+    dynatrace-metric-utils~=0.2.1
 
 [tool:pytest]
 testpaths = test

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -22,7 +22,7 @@ from opentelemetry.sdk.metrics.export import (
     MetricReader,
 )
 
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 
 
 def configure_dynatrace_metrics_export(

--- a/src/dynatrace/opentelemetry/metrics/export/_factory.py
+++ b/src/dynatrace/opentelemetry/metrics/export/_factory.py
@@ -162,10 +162,12 @@ class _OTelDynatraceMetricsFactory:
             return attributes
 
         return dict(
-            filter(lambda attr: self._is_string_value(attr[1]),
+            filter(lambda attr: \
+                       self._is_valid_dimension_key_type(attr[0]) and
+                       self._is_valid_dimension_value_type(attr[1]),
                    attributes.items()))
 
-    def _is_string_value(self, value):
+    def _is_valid_dimension_value_type(self, value) -> bool:
         if isinstance(value, str):
             return True
 
@@ -173,3 +175,13 @@ class _OTelDynatraceMetricsFactory:
             "Skipping unsupported dimension with value type '%s'",
             type(value).__name__)
         return False
+
+    def _is_valid_dimension_key_type(self, key) -> bool:
+        if isinstance(key, str):
+            return True
+
+        self.__logger.warning(
+            "Skipping unsupported dimension key value type '%s'",
+            type(key).__name__)
+        return False
+

--- a/src/dynatrace/opentelemetry/metrics/export/_factory.py
+++ b/src/dynatrace/opentelemetry/metrics/export/_factory.py
@@ -170,6 +170,6 @@ class _OTelDynatraceMetricsFactory:
             return True
 
         self.__logger.warning(
-            "Skipping unsupported dimension with value type %s",
-            type(value))
+            "Skipping unsupported dimension with value type '%s'",
+            type(value).__name__)
         return False

--- a/src/dynatrace/opentelemetry/metrics/export/_factory.py
+++ b/src/dynatrace/opentelemetry/metrics/export/_factory.py
@@ -162,9 +162,9 @@ class _OTelDynatraceMetricsFactory:
             return attributes
 
         return dict(
-            filter(lambda attr: \
-                       self._is_valid_dimension_key_type(attr[0]) and
-                       self._is_valid_dimension_value_type(attr[1]),
+            filter(lambda attr:
+                   self._is_valid_dimension_key_type(attr[0])
+                   and self._is_valid_dimension_value_type(attr[1]),
                    attributes.items()))
 
     def _is_valid_dimension_value_type(self, value) -> bool:
@@ -184,4 +184,3 @@ class _OTelDynatraceMetricsFactory:
             "Skipping unsupported dimension key value type '%s'",
             type(key).__name__)
         return False
-

--- a/src/dynatrace/opentelemetry/metrics/export/_factory.py
+++ b/src/dynatrace/opentelemetry/metrics/export/_factory.py
@@ -96,13 +96,13 @@ class _OTelDynatraceMetricsFactory:
             return self._metric_factory.create_float_counter_delta(
                 metric.name,
                 point.value,
-                self._retain_string_valued_dimensions(point.attributes),
+                self._filter_dimensions(point.attributes),
                 int(point.time_unix_nano / 1000000))
         if isinstance(point.value, int):
             return self._metric_factory.create_int_counter_delta(
                 metric.name,
                 point.value,
-                self._retain_string_valued_dimensions(point.attributes),
+                self._filter_dimensions(point.attributes),
                 int(point.time_unix_nano / 1000000))
 
     def _to_dynatrace_gauge(self, metric: Metric,
@@ -111,13 +111,13 @@ class _OTelDynatraceMetricsFactory:
             return self._metric_factory.create_float_gauge(
                 metric.name,
                 point.value,
-                self._retain_string_valued_dimensions(point.attributes),
+                self._filter_dimensions(point.attributes),
                 int(point.time_unix_nano / 1000000))
         if isinstance(point.value, int):
             return self._metric_factory.create_int_gauge(
                 metric.name,
                 point.value,
-                self._retain_string_valued_dimensions(point.attributes),
+                self._filter_dimensions(point.attributes),
                 int(point.time_unix_nano / 1000000))
 
     def _histogram_to_dynatrace_metric(self, metric: Metric,
@@ -136,7 +136,7 @@ class _OTelDynatraceMetricsFactory:
             _get_histogram_max(point),
             point.sum,
             sum(point.bucket_counts),
-            self._retain_string_valued_dimensions(point.attributes),
+            self._filter_dimensions(point.attributes),
             int(point.time_unix_nano / 1000000))
 
     def _log_temporality_mismatch(
@@ -154,7 +154,7 @@ class _OTelDynatraceMetricsFactory:
                               metric.data.aggregation_temporality.name,
                               supported_temporality.name)
 
-    def _retain_string_valued_dimensions(
+    def _filter_dimensions(
             self,
             attributes: Optional[Mapping]) -> Optional[Mapping[str, str]]:
 

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -597,8 +597,8 @@ class TestExporter(unittest.TestCase):
             "dict": {"a": "b"},
         }
 
-        self._assert_lines_created_correctly(mock_post, instrument_type,
-                                             attributes, expected)
+        self._assert_lines_created_correctly(instrument_type, attributes,
+                                             expected, mock_post)
 
     @parameterized.expand([
         ("int gauge", "gauge,20"),
@@ -621,12 +621,11 @@ class TestExporter(unittest.TestCase):
             3.2: "float",
         }
 
-        self._assert_lines_created_correctly(mock_post, instrument_type,
-                                             attributes,
-                                             expected)
+        self._assert_lines_created_correctly(instrument_type, attributes,
+                                             expected, mock_post)
 
-    def _assert_lines_created_correctly(self, mock_post, instrument_type,
-                                        attributes, expected):
+    def _assert_lines_created_correctly(self, instrument_type, attributes,
+                                        expected, mock_post):
         expected = \
             "my.instr,string=value,dt.metrics.source=opentelemetry {0} {1}" \
                 .format(expected, int(self._test_timestamp_millis))

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -19,7 +19,6 @@ from typing import Sequence, Union
 from unittest import mock
 from unittest.mock import patch
 
-import pytest
 import requests
 from dynatrace.opentelemetry.metrics.export import (
     _DynatraceMetricsExporter,
@@ -170,7 +169,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="{0}.my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,delta=10 {1}"
-            .format(prefix, self._test_timestamp_millis),
+                .format(prefix, self._test_timestamp_millis),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -194,7 +193,7 @@ class TestExporter(unittest.TestCase):
     @patch('dynatrace.metric.utils._dynatrace_metadata_enricher'
            '.DynatraceMetadataEnricher._get_metadata_file_content')
     def test_dynatrace_metadata_enrichment_with_default_attributes(
-        self, mock_enricher, mock_post):
+            self, mock_enricher, mock_post):
         mock_post.return_value = self._get_session_response()
 
         # attributes coming from the Dynatrace metadata enricher
@@ -333,7 +332,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,delta=10 {0}"
-            .format(self._test_timestamp_millis),
+                .format(self._test_timestamp_millis),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -378,7 +377,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,10 {0}"
-            .format(str(int(self._test_timestamp_nanos / 1000000))),
+                .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -393,7 +392,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,10 {0}"
-            .format(str(int(self._test_timestamp_nanos / 1000000))),
+                .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -415,7 +414,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=-3,max=12,sum=87,count=12 {0}"
-            .format(str(int(self._test_timestamp_nanos / 1000000))),
+                .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -453,7 +452,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=0,max=10,sum=87,count=12 {0}"
-            .format(str(int(self._test_timestamp_nanos / 1000000))),
+                .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -810,20 +809,6 @@ class TestExporter(unittest.TestCase):
             r.status_code = 200
             r._content = str.encode('{}')
         return r
-
-
-def _create_gauge_outside(self, value: int, attributes: dict = None) -> Gauge:
-    if not attributes:
-        attributes = self._attributes
-    return Gauge(
-        data_points=[
-            NumberDataPoint(
-                start_time_unix_nano=self._test_timestamp_nanos,
-                time_unix_nano=self._test_timestamp_nanos,
-                value=value,
-                attributes=attributes
-            )
-        ])
 
 
 if __name__ == '__main__':

--- a/test/test_exporter.py
+++ b/test/test_exporter.py
@@ -169,7 +169,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="{0}.my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,delta=10 {1}"
-            .format(prefix, self._test_timestamp_millis),
+                .format(prefix, self._test_timestamp_millis),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -193,7 +193,7 @@ class TestExporter(unittest.TestCase):
     @patch('dynatrace.metric.utils._dynatrace_metadata_enricher'
            '.DynatraceMetadataEnricher._get_metadata_file_content')
     def test_dynatrace_metadata_enrichment_with_default_attributes(
-        self, mock_enricher, mock_post):
+            self, mock_enricher, mock_post):
         mock_post.return_value = self._get_session_response()
 
         # attributes coming from the Dynatrace metadata enricher
@@ -332,7 +332,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry count,delta=10 {0}"
-            .format(self._test_timestamp_millis),
+                .format(self._test_timestamp_millis),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -377,7 +377,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,10 {0}"
-            .format(str(int(self._test_timestamp_nanos / 1000000))),
+                .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -392,7 +392,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,10 {0}"
-            .format(str(int(self._test_timestamp_nanos / 1000000))),
+                .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -414,7 +414,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=-3,max=12,sum=87,count=12 {0}"
-            .format(str(int(self._test_timestamp_nanos / 1000000))),
+                .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -452,7 +452,7 @@ class TestExporter(unittest.TestCase):
         mock_post.assert_called_once_with(
             self._ingest_endpoint,
             data="my.instr,l1=v1,l2=v2,dt.metrics.source=opentelemetry gauge,min=0,max=10,sum=87,count=12 {0}"
-            .format(str(int(self._test_timestamp_nanos / 1000000))),
+                .format(str(int(self._test_timestamp_nanos / 1000000))),
             headers=self._headers)
 
     @patch.object(requests.Session, 'post')
@@ -646,7 +646,7 @@ class TestExporter(unittest.TestCase):
                 )
             ])
 
-    def _create_gauge(self, value: int, attributes: dict = None):
+    def _create_gauge(self, value: int, attributes: dict = None) -> Gauge:
         if not attributes:
             attributes = self._attributes
         return Gauge(


### PR DESCRIPTION
Drop attributes that have non-string dimension values, as they are currently unsupported.