### PR TITLE
Allow API/SDK versions 1.* instead of only 1.12.* and fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ meter = metrics.get_meter(__name__)
 
 # create a counter instrument and provide the first data point
 counter = meter.create_counter(
-    name="MyCounter",
+    name="my_counter",
     description="Description of MyCounter",
-    unit="1",
-    value_type=int
+    unit="1"
 )
 
 counter.add(25, {"dimension-1": "value-1"})

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires=
-    opentelemetry-api~=1.12.0
-    opentelemetry-sdk~=1.12.0
+    opentelemetry-api~=1.12
+    opentelemetry-sdk~=1.12
     requests~=2.25
     dynatrace-metric-utils~=0.2.1
 

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -22,7 +22,7 @@ from opentelemetry.sdk.metrics.export import (
     MetricReader,
 )
 
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 
 
 def configure_dynatrace_metrics_export(


### PR DESCRIPTION
Testing with the SDK release [1.13.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.13.0) revealed that the Exporter expects `1.12.*` instead of `1.*`. 

This PR:
  - updates the Exporter to allow any `1.*` version, instead of only `1.12.*`.
  - fixes outdated example in the `README.md` where the now removed `value_type` keyword argument was still used on instrument creation. 
  - bumps the exporter to version `1.0.2`.