### PR TITLE
Update otel dependencies to 1.14

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires=
-    opentelemetry-api~=1.12
-    opentelemetry-sdk~=1.12
+    opentelemetry-api~=1.14
+    opentelemetry-sdk~=1.14
     requests~=2.25
     dynatrace-metric-utils~=0.2.1
 


### PR DESCRIPTION
Releases since last update:

- [1.13.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.14.0)
- [1.14.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.13.0)

Neither release contains any data model changes or updates to the exporter interface