### PR TITLE
docs: remove duplicate instruction to install psutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,8 @@ counter.add(25, {"dimension-1": "value-1"})
 To run the [example](example/basic_example.py), clone this repository and change to the `opentelemetry-metric-python` folder, then run:
 
 ```shell
-pip install psutil      # the example exports cpu which is retrieved using psutil, this is not required by the exporter.
 pip install .           # install the Dynatrace exporter
-pip install psutil      # install package is used by the example to read CPU/Memory usage
+pip install psutil      # this package is used by the example to read CPU/Memory usage
 export LOGLEVEL=DEBUG   # (optional) Set the log level to debug to see more output (default is INFO)
 python example/basic_example.py
 ```


### PR DESCRIPTION
discovered that there's a duplicate instruction to install `psutil` to run the example. removed it and adapted the text a bit :slightly_smiling_face: 