### PR TITLE
docs: change development status classifier to inactive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 license = Apache-2.0
 platforms = any
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 7 - Inactive
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent

--- a/src/dynatrace/opentelemetry/metrics/export/__init__.py
+++ b/src/dynatrace/opentelemetry/metrics/export/__init__.py
@@ -22,7 +22,7 @@ from opentelemetry.sdk.metrics.export import (
     MetricReader,
 )
 
-VERSION = "1.0.2"
+VERSION = "1.0.3"
 
 
 def configure_dynatrace_metrics_export(


### PR DESCRIPTION
This PR changes the [development status classifier](https://pypi.org/classifiers/) to `7 - Inactive`, and prepares the release of a new version (`1.0.3`, including docs updates only), which will also update the `README` on [pypi.org](https://pypi.org/project/opentelemetry-exporter-dynatrace-metrics/) to include the [deprecation messaging from our `README` on this repo.](https://github.com/dynatrace-oss/opentelemetry-metric-python/blob/2163c30a4f9d598b781cd6ab6db48d3e61091d46/README.md?plain=1#L13-L21)
